### PR TITLE
Display character name in dialogue box

### DIFF
--- a/Dialogue.cpp
+++ b/Dialogue.cpp
@@ -8,14 +8,15 @@ Dialogue::~Dialogue() {
 
 }
 
-void Dialogue::set_dialogue(std::string main_text, std::vector<DialogueChoice*> dialogue_choices, bool are_color_options) {
-    this->dialogue = main_text;
+void Dialogue::set_dialogue(DialogueNode *dialogue_node, bool are_color_options) {
+    dialogue = dialogue_node->text;
     std::vector<std::string> choices_text;
-    for (DialogueChoice* dialogue_choice : dialogue_choices) {
+    for (DialogueChoice* dialogue_choice : dialogue_node->choices) {
         choices_text.push_back(dialogue_choice->choice_text);
     }
-    this->choices = choices_text;
-    this->color_options = are_color_options;
+    choices = choices_text;
+    color_options = are_color_options;
+    character_name = dialogue_node->character;
 }
 
 void Dialogue::draw_dialogue_box(glm::uvec2 const &window_size) {
@@ -24,6 +25,7 @@ void Dialogue::draw_dialogue_box(glm::uvec2 const &window_size) {
     float text_left_offset = 20.0f;
     float text_top_offset = 70.0f;
     float choices_bottom_offset = 20.0f;
+    float character_name_top_offset = 40.0f;
 
     // Render the box where text goes
     dialogue_box->set_drawable_size(window_size);
@@ -67,4 +69,10 @@ void Dialogue::draw_dialogue_box(glm::uvec2 const &window_size) {
         }
         choices_renderer->renderText(choices_text, choices_x_pos, choices_y_pos, choices_text_size, choices_text_color);
     }
+
+    // Render character name text
+    character_name_renderer->set_drawable_size(window_size);
+    float character_name_x_pos = text_left_offset + (window_size.x - dialogue_box->size.x * dialogue_box_scale) * 0.5f;
+    float character_name_y_pos = dialogue_box_bottom_offset + dialogue_box->size.y * dialogue_box_scale - character_name_top_offset;
+    character_name_renderer->renderText(character_name, character_name_x_pos, character_name_y_pos, character_name_text_size, character_name_text_color);
 }

--- a/Dialogue.hpp
+++ b/Dialogue.hpp
@@ -16,6 +16,7 @@ struct Dialogue {
     Sprite *dialogue_box;
     std::string dialogue;
     std::vector<std::string> choices;
+    std::string character_name;
     bool color_options;
 
     // Font renderers 
@@ -25,12 +26,15 @@ struct Dialogue {
 	// Configuration for main text, choices and inputs
 	TextRenderer *dialogue_text_renderer = patua_renderer;
 	TextRenderer *choices_renderer = patua_renderer;
+    TextRenderer *character_name_renderer = patua_renderer;
     float dialogue_text_size = 0.5f;
     glm::vec3 dialogue_text_color = glm::vec3(0.0f, 0.0f, 0.0f);
     float choices_text_size = 0.5f;
     glm::vec3 choices_text_color = glm::vec3(0.0f, 0.0f, 0.0f);
+    float character_name_text_size = 0.5f;
+    glm::vec3 character_name_text_color = glm::vec3(1.0f, 1.0f, 1.0f);
 
 
-    void set_dialogue(std::string main_text, std::vector<DialogueChoice*> dialogue_choices, bool are_color_options);
+    void set_dialogue(DialogueNode *dialogue_node, bool are_color_options);
     void draw_dialogue_box(glm::uvec2 const &window_size);
 };

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -69,7 +69,7 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 				}
 				// set key_down to true to prevent double counting
 				key_down = true;
-			} else if (evt.key.keysym.sym == SDLK_RETURN) {
+			} else if (!current_beatmap.started && evt.key.keysym.sym == SDLK_RETURN) {
 				if (current_node->choices.size() > 0) {
 					// Advance text based on current choice
 					// Get the next node to advance to

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -41,7 +41,7 @@ PlayMode::PlayMode() {
 	current_dialogue = Dialogue();
 
 	current_node = current_tree->get_current_node();
-	current_dialogue.set_dialogue(current_node->text, current_node->choices, false);
+	current_dialogue.set_dialogue(current_node, false);
 }
 
 PlayMode::~PlayMode() {}
@@ -85,7 +85,7 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 					current_tree->current_node_pid = next_pid;
 					current_node = current_tree->get_current_node();
 
-					current_dialogue.set_dialogue(current_node->text, current_node->choices, in_beatmap);
+					current_dialogue.set_dialogue(current_node, in_beatmap);
 				}
 			}
 		}
@@ -153,7 +153,7 @@ void PlayMode::update(float elapsed) {
 		current_tree->current_node_pid = next_pid;
 		current_node = current_tree->get_current_node();
 
-		current_dialogue.set_dialogue(current_node->text, current_node->choices, false);
+		current_dialogue.set_dialogue(current_node, false);
 
 		// Reset the beatmap
 		current_beatmap = Beatmap();


### PR DESCRIPTION
Pass in current_node to set dialogue for the dialogue box. Also updated if condition when checking for enter-keystrokes, because had edge case where user could hit enter while the beatmap was fading in (even though they shouldn't be able to).