### PR TITLE
Updating Dialogue Logic

### DIFF
--- a/Dialogue.cpp
+++ b/Dialogue.cpp
@@ -59,8 +59,8 @@ void Dialogue::draw_dialogue_box(glm::uvec2 const &window_size) {
     float choices_x_pos = text_left_offset + (window_size.x - dialogue_box->size.x * dialogue_box_scale) * 0.5f;
     float choices_y_pos = dialogue_box_bottom_offset + choices_bottom_offset;
     if (color_options) {
-        if (choices.size() != 2) {
-            std::cout << "Invalid amount of choices: " << choices.size() << std::endl;
+        if (choices.size() != 4) {
+            std::cout << "Invalid amount of choices: " << choices.size() << " (expected 4)"<< std::endl;
         }
         else {
             std::string choice1("> ");

--- a/DialogueManager.cpp
+++ b/DialogueManager.cpp
@@ -139,6 +139,7 @@ void DialogueTree::choose_choice(size_t index) {
         int choice_node_pid = current_node->choices[index]->pid;
         DialogueNode *choice_node = find_node_from_pid(choice_node_pid);
         current_node = choice_node;
+        relationship_points += current_node->relationshipChange;
 
         while (current_node->isCheckNode) {
             assert(current_node->choices.size() == 2);
@@ -147,9 +148,9 @@ void DialogueTree::choose_choice(size_t index) {
             } else {
                 choice_node_pid = current_node->choices[1]->pid;
             }
-
             choice_node = find_node_from_pid(choice_node_pid);
             current_node = choice_node;
+            relationship_points += current_node->relationshipChange;
         }
     }
     else {

--- a/DialogueManager.hpp
+++ b/DialogueManager.hpp
@@ -19,9 +19,14 @@ struct DialogueChoice {
 };
 
 struct DialogueNode {
+    bool isCheckNode;
+    int minRelationship;
+
     std::string character;
     bool startBeatmap;
     std::string beatmapPath;
+    int relationshipChange;
+
     std::string text;
     std::vector<DialogueChoice*> choices;
 };
@@ -29,13 +34,11 @@ struct DialogueNode {
 struct DialogueTree {
     std::unordered_map<int, DialogueNode*> dialogue_nodes;
     int start_node_pid;
+    int relationship_points;
 
     DialogueNode* current_node;
 
-    void start_tree() {
-        current_node = find_node_from_pid(start_node_pid);
-    };
-
+    void start_tree();
     void choose_choice(size_t index);
 
 private:

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -108,8 +108,6 @@ void PlayMode::update(float elapsed) {
     } else {
         time_elapsed += elapsed;
     }
-
-	// TODO: function to set "started" to true to start the fade in process
 	
 	// start rhythm level when fade complete
 	if (rhythm_ui_alpha < 1.0f && current_beatmap.started && !current_beatmap.in_progress) {
@@ -139,9 +137,8 @@ void PlayMode::update(float elapsed) {
 	if (current_beatmap.beatmap_done()) {
 		// Everything is done for the beatmap
 
-		// Get the next node to advance ton based on beatmap results
+		// Get the next node to advance to based on beatmap results
 		current_tree->choose_choice(current_beatmap.get_choice());
-
 		current_dialogue.set_dialogue(current_tree->current_node, false);
 
 		// Reset the beatmap

--- a/constants.hpp
+++ b/constants.hpp
@@ -18,9 +18,9 @@ const float x_pos_ratio = 0.05f;
 const float arrow_size = 0.125f;
 
 const glm::vec2 up_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.9f);
-const glm::vec2 down_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.8f);
-const glm::vec2 left_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.7f);
-const glm::vec2 right_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.6f);
+const glm::vec2 left_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.8f);
+const glm::vec2 right_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.7f);
+const glm::vec2 down_arrow_destination_norm = glm::vec2(x_pos_ratio, 0.6f);
 
 // scoring guidelines
 const float FULL_SCORE_THRESH = (0.05f * 0.05f);

--- a/dist/dialogue/prototype.json
+++ b/dist/dialogue/prototype.json
@@ -84,11 +84,11 @@
       ]
     },
     {
-      "text": "{\"character\": \"Jim\", \"startBeatmap\": \"levels/proto/bourree.beatmap\"}\nWhy don't you go first?\n[[Next->StartSong]]",
+      "text": "{\"character\": \"Jim\", \"startBeatmap\": \"levels/proto/bourree.beatmap\"}\nWhy don't you go first?\n[[Next->Proto_Song]]",
       "links": [
         {
           "name": "Next",
-          "link": "StartSong",
+          "link": "Proto_Song",
           "pid": "7"
         }
       ],
@@ -100,7 +100,7 @@
       }
     },
     {
-      "text": "{\"character\": \"Jim\"}\nSo what are you doing for your prototype?\n[[Lie->Choice1]]\n[[Tell the Truth->Choice2]]",
+      "text": "{\"character\": \"Jim\"}\nSo what are you doing for your prototype?\n[[Lie->Choice1]]\n[[Tell the Truth->Choice2]]\n[[Hesitation->Choice3]]\n[[Failure->Choice4]]",
       "links": [
         {
           "name": "Lie",
@@ -111,9 +111,19 @@
           "name": "Tell the Truth",
           "link": "Choice2",
           "pid": "9"
+        },
+        {
+          "name": "Hesitation",
+          "link": "Choice3",
+          "pid": "10"
+        },
+        {
+          "name": "Failure",
+          "link": "Choice4",
+          "pid": "11"
         }
       ],
-      "name": "StartSong",
+      "name": "Proto_Song",
       "pid": "7",
       "position": {
         "x": "825",
@@ -121,21 +131,106 @@
       }
     },
     {
-      "text": "{\"character\": \"Narrator\"}\nQuickly pulling up Flappy Bird on your computer, you pretend that you have a working prototype and present it to the class. Your classmates immediately recognize that you are a cheater and a bad liar and you shamefully are removed from the class.",
+      "text": "{\"character\": \"Narrator\", \"relationship\": -10}\nQuickly pulling up Flappy Bird on your computer, you pretend that you have a working prototype and present it to the class. Your classmates immediately recognize that you are a cheater and a bad liar and you shamefully are removed from the class.\n[[Next->Check Node]]",
+      "links": [
+        {
+          "name": "Next",
+          "link": "Check Node",
+          "pid": "14"
+        }
+      ],
       "name": "Choice1",
       "pid": "8",
       "position": {
-        "x": "825",
-        "y": "1075"
+        "x": "775",
+        "y": "1125"
       }
     },
     {
-      "text": "{\"character\": \"Narrator\"}\nYou tell the rest of class about your life story, adding in a few embellishments for bonus sympathy points. Jim grunts in disappointment and calls on the next person. Your grade may haved suffered, but at least your reputation remains untarnished.",
+      "text": "{\"character\": \"Narrator\", \"relationship\": 10}\nYou tell the rest of class about your life story, adding in a few embellishments for bonus sympathy points. Jim grunts in disappointment and calls on the next person. Your grade may haved suffered, but at least your reputation remains untarnished.\n[[Next->Check Node]]",
+      "links": [
+        {
+          "name": "Next",
+          "link": "Check Node",
+          "pid": "14"
+        }
+      ],
       "name": "Choice2",
       "pid": "9",
       "position": {
+        "x": "1025",
+        "y": "1125"
+      }
+    },
+    {
+      "text": "{\"character\": \"Narrator\", \"relationship\": -10}\nYou stand there, saying nothing, and hoping that things will work out. Unfortunately... it did not. Jim sends you home to reflect on your actions.\n[[Next->Check Node]]",
+      "links": [
+        {
+          "name": "Next",
+          "link": "Check Node",
+          "pid": "14"
+        }
+      ],
+      "name": "Choice3",
+      "pid": "10",
+      "position": {
+        "x": "650",
+        "y": "1125"
+      }
+    },
+    {
+      "text": "{\"character\": \"Narrator\", \"relationship\": -10}\nYou stumble over yourself, trying to say some words but only spitting out an incoherent mess. The class looks at you in confusion, and Jim's facial expression can only be described with immense disappointment. You leave the classroom in distress.\n[[Next->Check Node]]",
+      "links": [
+        {
+          "name": "Next",
+          "link": "Check Node",
+          "pid": "14"
+        }
+      ],
+      "name": "Choice4",
+      "pid": "11",
+      "position": {
+        "x": "900",
+        "y": "1125"
+      }
+    },
+    {
+      "text": "{}\nBad Ending\n",
+      "name": "Bad Ending",
+      "pid": "12",
+      "position": {
+        "x": "750",
+        "y": "1400"
+      }
+    },
+    {
+      "text": "{}\nGood Ending\n",
+      "name": "Good Ending",
+      "pid": "13",
+      "position": {
         "x": "950",
-        "y": "1075"
+        "y": "1400"
+      }
+    },
+    {
+      "text": "{\"checkNode\": true, \"minRelationship\": 0}\n\n[[Fail->Bad Ending]]\n[[Pass->Good Ending]]",
+      "links": [
+        {
+          "name": "Fail",
+          "link": "Bad Ending",
+          "pid": "12"
+        },
+        {
+          "name": "Pass",
+          "link": "Good Ending",
+          "pid": "13"
+        }
+      ],
+      "name": "Check Node",
+      "pid": "14",
+      "position": {
+        "x": "850",
+        "y": "1275"
       }
     }
   ],

--- a/dist/dialogue/prototype.json
+++ b/dist/dialogue/prototype.json
@@ -213,17 +213,17 @@
       }
     },
     {
-      "text": "{\"checkNode\": true, \"minRelationship\": 0}\n\n[[Fail->Bad Ending]]\n[[Pass->Good Ending]]",
+      "text": "{\"checkNode\": true, \"minRelationship\": 0}\n\n[[Pass->Good Ending]]\n[[Fail->Bad Ending]]",
       "links": [
-        {
-          "name": "Fail",
-          "link": "Bad Ending",
-          "pid": "12"
-        },
         {
           "name": "Pass",
           "link": "Good Ending",
           "pid": "13"
+        },
+        {
+          "name": "Fail",
+          "link": "Bad Ending",
+          "pid": "12"
         }
       ],
       "name": "Check Node",


### PR DESCRIPTION
Resolves #28 and resolves #40
Adding in additional fields to dialogue to account for all four possible endings from a beatmap

Twine demonstrating flow of four post-beatmap choices and check nodes:
![image](https://user-images.githubusercontent.com/43687061/200121454-89fafc05-6b2f-426a-b1e6-eaee16e207cd.png)

Hesitation ending reachable:
![image](https://user-images.githubusercontent.com/43687061/200121466-16be0d2c-40ba-4a3f-9b3f-c26be821f71d.png)
