### PR TITLE
Make choices more apparent

### DIFF
--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -93,7 +93,11 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			} else if (!current_beatmap.started && evt.key.keysym.sym == SDLK_RETURN) {
 				if (!current_dialogue.finished_text_rendering()) {
 					current_dialogue.finish_text_rendering();
-				} else {
+					// if multiple choices, set a timer so we can't choose a choice immediately
+					if (current_dialogue.choices.size() > 1) {
+						time_since_enter = 0.0f;
+					}
+				} else if (time_since_enter > delay_after_enter) {
 					// Advance text based on current choice
 					// Get the next node to advance to
 					if (current_tree->current_node->choices.size() > 0) {
@@ -188,6 +192,9 @@ void PlayMode::update(float elapsed) {
 	}
 
 	current_dialogue.update_dialogue_box(elapsed);
+
+	// update time elapsed since we last pressed enter; used for delay when a choice appears
+	time_since_enter += elapsed;
 }
 
 void PlayMode::draw(glm::uvec2 const &drawable_size, glm::uvec2 const &window_size) {

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -38,6 +38,7 @@ struct PlayMode : Mode {
 		uint8_t pressed = 0;
 		float timestamp = 0.0f;
 	} left, right, down, up, ret;
+	float time_since_enter;
 
 	//local copy of the game scene (so code can change it during gameplay):
 	Scene scene;

--- a/constants.hpp
+++ b/constants.hpp
@@ -70,3 +70,6 @@ const float PERFECT_HIT = 0.9999f;
 const float GREAT_HIT = 0.9f;
 const float GOOD_HIT = 0.8f;
 const float FAIL_HIT = 0.5f;
+
+// dialogue constants
+const float delay_after_enter = 0.5f;


### PR DESCRIPTION
Player now has to wait half a second before selecting an option in the dialogue box if they skipped the text. The time the player has to wait can be modified in constants.hpp